### PR TITLE
Webots seed, unique object name, no preprocess after init, merge_spaces after init, no reuse of already initialized object.

### DIFF
--- a/eager_bridge_gazebo/src/eager_bridge_gazebo/gazebo_bridge.py
+++ b/eager_bridge_gazebo/src/eager_bridge_gazebo/gazebo_bridge.py
@@ -107,7 +107,7 @@ class GazeboBridge(PhysicsBridge):
                 msg_topic,
                 msg_type, 
                 functools.partial(self._sensor_callback, name=name, sensor=sensor)))
-            self._sensor_services.append(rospy.Service(topic + "/" + sensor, get_message_from_def(space), 
+            self._sensor_services.append(rospy.Service(topic + "/sensors/" + sensor, get_message_from_def(space),
                                                        functools.partial(self._service, 
                                                                          buffer=self._sensor_buffer, 
                                                                          name=name, obs_name=sensor, 
@@ -123,7 +123,7 @@ class GazeboBridge(PhysicsBridge):
             joint_names = actuators[actuator]["names"]
             space = actuators[actuator]['space']
             server_name = name + "/" + actuators[actuator]["server_name"]
-            get_action_srv = rospy.ServiceProxy(topic + "/" + actuator, get_message_from_def(space))
+            get_action_srv = rospy.ServiceProxy(topic + "/actuators/" + actuator, get_message_from_def(space))
             set_action_srv = FollowJointTrajectoryActionServer(joint_names, server_name).act
             actuator_services[actuator] = (get_action_srv, set_action_srv)
         self._actuator_services[name] = actuator_services
@@ -135,17 +135,7 @@ class GazeboBridge(PhysicsBridge):
             state_params = states[state]
             space = state_params['space']
             robot_states[state] = [get_value_from_def(space)]*len(states[state])
-            # msg_topic = name + "/" + state_params["topic"]
-            # msg_name = state_params["msg_name"]
-            # msg_type = getattr(state_msgs.msg, msg_name)
-            # rospy.logdebug("Waiting for message topic {}".format(msg_topic))
-            # rospy.wait_for_message(msg_topic, msg_type)
-            # rospy.logdebug("Sensor {} received message from topic {}".format(state, msg_topic))
-            # self._state_subscribers.append(rospy.Subscriber(
-            #     msg_topic,
-            #     msg_type,
-            #     functools.partial(self._state_callback, state=state)))
-            self._sensor_services.append(rospy.Service(topic + "/" + state, get_message_from_def(space), 
+            self._sensor_services.append(rospy.Service(topic + "/states/" + state, get_message_from_def(space),
                                                        functools.partial(self._service, 
                                                                          buffer=self._state_buffer, 
                                                                          name=name, 

--- a/eager_bridge_gazebo/src/eager_bridge_gazebo/gazebo_node.py
+++ b/eager_bridge_gazebo/src/eager_bridge_gazebo/gazebo_node.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
-from eager_bridge_gazebo.gazebo import GazeboBridge
+from eager_bridge_gazebo.gazebo_bridge import GazeboBridge
 
 if __name__ == '__main__':
 

--- a/eager_bridge_webots/src/eager_bridge_webots/webots_bridge.py
+++ b/eager_bridge_webots/src/eager_bridge_webots/webots_bridge.py
@@ -3,7 +3,7 @@ import functools
 import re
 from eager_core.physics_bridge import PhysicsBridge
 from eager_core.utils.file_utils import substitute_xml_args
-from eager_core.utils.message_utils import get_value_from_def, get_message_from_def, get_response_from_def
+from eager_core.utils.message_utils import get_value_from_def, get_message_from_def, get_response_from_def, get_length_from_def, get_dtype_from_def
 from webots_ros.msg import Float64Stamped
 from webots_ros.srv import set_int, set_float
 from sensor_msgs.msg import Image
@@ -72,7 +72,7 @@ class WeBotsBridge(PhysicsBridge):
             sensor = sensors[sensor_name]
             topic_list = sensor['names']
             space = sensor['space']
-            robot_sensors[sensor_name] = [get_value_from_def(space)]*len(topic_list)
+            robot_sensors[sensor_name] = [get_value_from_def(space)] * get_length_from_def(space)
             for idx, webots_sensor_name in enumerate(topic_list):
                 enable_sensor = rospy.ServiceProxy(name + "/" + webots_sensor_name + "/enable", set_int)
 
@@ -90,11 +90,12 @@ class WeBotsBridge(PhysicsBridge):
                     else:
                         self._sensor_subscribers.append(rospy.Subscriber(name + "/" + webots_sensor_name + "/value",
                             Float64Stamped, functools.partial(self._sensor_callback, name=name, sensor=sensor_name, pos=idx)))
-            self._sensor_services.append(rospy.Service(topic + "/" + sensor_name, get_message_from_def(space), functools.partial(self._service,
-                                                                                                buffer=self._sensor_buffer,
-                                                                                                name=name,
-                                                                                                obs_name=sensor_name,
-                                                                                                message_type=get_response_from_def(space))))
+            self._sensor_services.append(rospy.Service(topic + "/sensors/" + sensor_name, get_message_from_def(space),
+                                                       functools.partial(self._service,
+                                                                         buffer=self._sensor_buffer,
+                                                                         name=name,
+                                                                         obs_name=sensor_name,
+                                                                         message_type=get_response_from_def(space))))
         self._sensor_buffer[name] = robot_sensors
     
     def _init_actuators(self, topic, name, actuators):
@@ -107,7 +108,7 @@ class WeBotsBridge(PhysicsBridge):
             for webots_actuator_name in topic_list:
                 set_action_srvs.append(rospy.ServiceProxy(name + "/" + webots_actuator_name + "/set_position", set_float))
 
-            get_action_srv = rospy.ServiceProxy(topic + "/" + actuator_name, get_message_from_def(space))
+            get_action_srv = rospy.ServiceProxy(topic + "/actuators/" + actuator_name, get_message_from_def(space))
             robot_actuators[actuator_name] = (get_action_srv, set_action_srvs)
         self._actuator_services[name] = robot_actuators
 
@@ -117,18 +118,19 @@ class WeBotsBridge(PhysicsBridge):
             state = states[state_name]
             topic_list = state['names']
             space = state['space']
-            robot_states[state_name] = [get_value_from_def(space)]*len(topic_list)
+            robot_states[state_name] = [get_value_from_def(space)] * get_length_from_def(space)
             # for idx, webots_sensor_name in enumerate(topic_list):
             #     enable_sensor = rospy.ServiceProxy(name + "/" + webots_sensor_name + "/enable", set_int)
             #     success = enable_sensor(self._step_time)
             #     if success:
             #         self._sensor_subscribers.append(rospy.Subscriber(name + "/" + webots_sensor_name + "/value",
             #             Float64Stamped, functools.partial(self._sensor_callback, name=name, sensor=sensor, pos=idx)))
-            self._sensor_services.append(rospy.Service(topic + "/" + state_name, get_message_from_def(space), functools.partial(self._service,
-                                                                                                buffer=self._state_buffer,
-                                                                                                name=name,
-                                                                                                obs_name=state_name,
-                                                                                                message_type=get_response_from_def(space))))
+            self._sensor_services.append(rospy.Service(topic + "/states/" + state_name, get_message_from_def(space),
+                                                       functools.partial(self._service,
+                                                                         buffer=self._state_buffer,
+                                                                         name=name,
+                                                                         obs_name=state_name,
+                                                                         message_type=get_response_from_def(space))))
         self._state_buffer[name] = robot_states
 
     def _sensor_callback(self, data, name, sensor, pos):

--- a/eager_bridge_webots/src/eager_bridge_webots/webots_node.py
+++ b/eager_bridge_webots/src/eager_bridge_webots/webots_node.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
-from eager_bridge_webots.webots import WeBotsBridge
+from eager_bridge_webots.webots_bridge import WeBotsBridge
 
 if __name__ == '__main__':
 

--- a/eager_core/src/eager_core/eager_env.py
+++ b/eager_core/src/eager_core/eager_env.py
@@ -53,7 +53,7 @@ class BaseEagerEnv(gym.Env):
                 objects_reg.append(ObjectMsg(object.type, object.name, object.args))
 
         register_service = rospy.ServiceProxy(self.name + '/register', Register)
-        register_service.wait_for_service(200000)
+        register_service.wait_for_service(20)
         register_service(objects_reg)
 
     def _init_listeners(self, objects: List[Object] = [], observers: List['Observer'] = []) -> None:

--- a/eager_core/src/eager_core/objects.py
+++ b/eager_core/src/eager_core/objects.py
@@ -1,5 +1,5 @@
 import gym, gym.spaces
-from eager_core.utils.file_utils import load_yaml, substitute_xml_args, check_object_config
+from eager_core.utils.file_utils import load_yaml, substitute_xml_args
 from eager_core.utils.gym_utils import (get_space_from_space_msg, get_message_from_space,
                                         get_def_from_space, get_response_from_space,
                                         get_space_from_def)
@@ -60,7 +60,7 @@ class Sensor(BaseRosObject):
         if self.observation_space is None:
             self.observation_space = self._infer_space(base_topic)
         
-        self._get_sensor_service = rospy.ServiceProxy(self.get_topic(base_topic), get_message_from_space(self.observation_space))
+        self._get_sensor_service = rospy.ServiceProxy(self.get_topic(base_topic + '/sensors'), get_message_from_space(self.observation_space))
 
     def get_obs(self) -> object: #Type depends on space
         response = self._get_sensor_service()
@@ -95,10 +95,10 @@ class State(BaseRosObject):
 
         self._buffer = self.state_space.sample()
 
-        self._get_state_service = rospy.ServiceProxy(self.get_topic(base_topic),
+        self._get_state_service = rospy.ServiceProxy(self.get_topic(base_topic + '/states'),
                                                  get_message_from_space(self.state_space))
 
-        self._send_state_service = rospy.Service(self.get_topic(base_topic), get_message_from_space(self.state_space),
+        self._send_state_service = rospy.Service(self.get_topic(base_topic + '/resets'), get_message_from_space(self.state_space),
                                                   self._send_state)
 
     def get_state(self) -> object:  # Type depends on space
@@ -164,7 +164,7 @@ class Actuator(BaseRosObject):
         else:
             self._buffer = self.action_space.sample()
             
-            self._act_service = rospy.Service(self.get_topic(base_topic), get_message_from_space(self.action_space), self._send_action)
+            self._act_service = rospy.Service(self.get_topic(base_topic + '/actuators'), get_message_from_space(self.action_space), self._send_action)
     
     def set_action(self, action: object) -> None:
         self._buffer = action
@@ -243,7 +243,6 @@ class Object(BaseRosObject):
                ) -> 'Object':
 
         params = load_yaml(package_name, object_type)
-        check_object_config(params)
 
         sensors = []
         if 'sensors' in params:

--- a/eager_core/src/eager_core/utils/file_utils.py
+++ b/eager_core/src/eager_core/utils/file_utils.py
@@ -43,33 +43,3 @@ def is_namespace_empty(ns):
             topic_lst.append(topic)
     ns_empty = not len(srvs_lst) + len(topic_lst) > 0
     return ns_empty
-
-def check_object_config(config):
-    # Check that unique names are given to state/actuator/sensor categories
-    unique_names = []
-    if 'sensors' in config:
-        for sens_name, sensor in config['sensors'].items():
-            if sens_name in unique_names:
-                str_err = 'Name "%s" defined multiple times in object config. Name must be unique over all states/actuators/sensors.' % sens_name
-                rospy.logerr(str_err)
-                raise ValueError(str_err)
-            else:
-                unique_names.append(sens_name)
-
-    if 'actuators' in config:
-        for act_name, actuator in config['actuators'].items():
-            if act_name in unique_names:
-                str_err = 'Name "%s" defined multiple times in object config. Name must be unique over all states/actuators/sensors.' % act_name
-                rospy.logerr(str_err)
-                raise ValueError(str_err)
-            else:
-                unique_names.append(act_name)
-
-    if 'states' in config:
-        for state_name, state in config['states'].items():
-            if state_name in unique_names:
-                str_err = 'Name "%s" defined multiple times in object config. Name must be unique over all states/actuators/sensors.' % state_name
-                rospy.logerr(str_err)
-                raise ValueError(str_err)
-            else:
-                unique_names.append(state_name)


### PR DESCRIPTION
- Check whether robot names are unique: closes  #76.
- Produce error if object, already initialized is used another time. closes #114.
- Check that names for states/sensors/actuators are unique. closes #79.
- Implement warning for Webots seed.
- Only add_preprocess before object initialization. Only merge_spaces after object initialization. closes #45.