### PR TITLE
Fix real bridge and safe actions

### DIFF
--- a/eager_bridge_real/launch/real.launch
+++ b/eager_bridge_real/launch/real.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="name" default="ros_env" doc="Set the physics bridge name."/>
+    <group ns="$(arg name)">
+        <node name="physics_bridge" pkg="eager_bridge_real" type="real_node.py" output="screen"/>
+    </group>
+</launch>

--- a/eager_bridge_real/src/eager_bridge_real/real_bridge.py
+++ b/eager_bridge_real/src/eager_bridge_real/real_bridge.py
@@ -2,8 +2,8 @@ import rospy
 import roslaunch
 import functools
 import sensor_msgs.msg
-import eager_core.action_server
 from inspect import getmembers, isclass, isroutine
+import eager_core.action_server
 from eager_core.physics_bridge import PhysicsBridge
 from eager_core.utils.file_utils import substitute_xml_args
 from eager_core.utils.message_utils import get_value_from_def, get_message_from_def, get_response_from_def, get_length_from_def
@@ -51,7 +51,7 @@ class RealBridge(PhysicsBridge):
         uuid = roslaunch.rlutil.get_or_generate_uuid(None, False)
         roslaunch.configure_logging(uuid)
         launch = roslaunch.parent.ROSLaunchParent(uuid, roslaunch_file)
-        launch.start()
+        # launch.start()
 
     def _init_sensors(self, topic, name, sensors):
         self._sensor_buffer[name] = {}
@@ -75,9 +75,10 @@ class RealBridge(PhysicsBridge):
                     msg_name, attribute_name, valid_attributes))
             self._sensor_buffer[name][sensor] = [get_value_from_def(space)] * get_length_from_def(space)
             self._sensor_subscribers.append(rospy.Subscriber(
-                msg_topic,
-                msg_type,
-                functools.partial(self._sensor_callback, name=name, sensor=sensor, attribute=attribute)))
+                                            msg_topic,
+                                            msg_type,
+                                            functools.partial(self._sensor_callback, name=name, sensor=sensor,
+                                                              attribute=attribute)))
             self._sensor_services.append(rospy.Service(topic + "/sensors/" + sensor, get_message_from_def(space),
                                                        functools.partial(self._service,
                                                                          buffer=self._sensor_buffer,

--- a/eager_bridge_real/src/eager_bridge_real/real_node.py
+++ b/eager_bridge_real/src/eager_bridge_real/real_node.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import rospy
-from eager_bridge_real.real import RealBridge
+from eager_bridge_real.real_bridge import RealBridge
 
 if __name__ == '__main__':
 

--- a/eager_process_safe_actions/launch/safe_actions.launch
+++ b/eager_process_safe_actions/launch/safe_actions.launch
@@ -12,6 +12,9 @@
   <arg name="checks_per_rad" doc="Specifies the number of collision checks per radian"/>
   <arg name="vel_limit" doc="Specifies the joint velocity limit in rad/s"/>
   <arg name="duration" doc="Specifies the duration for the joint trajectory point action in s"/>
+	<arg name="collision_height" doc="Specifies the height with respect to the base where the robot is assumed to be in collision."/>
+	<arg name="base_length" doc="Specifies the length around the base that is not considered as collision object. "/>
+	<arg name="workspace_length" doc="Specifies the size of the collision object."/>
 
 	<!-- MoveIt arguments -->
 	<arg name="allow_trajectory_execution" default="false" doc="Specifies whether MoveIt trajectory execution should be launched"/>
@@ -38,6 +41,9 @@
 	    <param name="vel_limit" value="$(arg vel_limit)"/>
 	    <param name="duration" value="$(arg duration)"/>
 			<param name="object_frame" value="$(arg object_frame)"/>
+			<param name="collision_height" value="$(arg collision_height)"/>
+			<param name="base_length" value="$(arg base_length)"/>
+			<param name="workspace_length" value="$(arg workspace_length)"/>
 	  </node>
 	</group>
 

--- a/eager_process_safe_actions/src/eager_process_safe_actions/safe_actions.py
+++ b/eager_process_safe_actions/src/eager_process_safe_actions/safe_actions.py
@@ -31,17 +31,58 @@ class SafeActions(ActionProcessor):
         self.checks_per_rad = rospy.get_param('~checks_per_rad')
         self.vel_limit = rospy.get_param('~vel_limit')
         self.duration = rospy.get_param('~duration')
+        self.collision_height = rospy.get_param('~collision_height')
+        self.base_length = rospy.get_param('~base_length')
+        self.workspace_length = rospy.get_param('~workspace_length')
 
         # Initialize Moveit Commander and Scene
         moveit_commander.roscpp_initialize(sys.argv)
         scene = moveit_commander.PlanningSceneInterface(synchronous=True)
 
+        # Five collision objects are added to the scene, such that the base is
+        # not in collision, while the rest of the surface is a collision object.
+
+        object_length = (self.workspace_length - self.base_length) / 2.0
+
         # Add a collision object to the scenes
-        p = PoseStamped()
-        p.header.frame_id = object_frame
-        p.pose.position.z = -0.05
-        p.pose.orientation.w = 1
-        scene.add_cylinder('base', p, 0.1, 1.5)
+        p0 = PoseStamped()
+        p0.header.frame_id = object_frame
+        p0.pose.position.z = - 0.05
+        p0.pose.orientation.w = 1
+
+        # Add a collision object to the scenes
+        p1 = PoseStamped()
+        p1.header.frame_id = object_frame
+        p1.pose.position.x = (object_length + self.base_length) / 2.0
+        p1.pose.position.z = self.collision_height / 2.0
+        p1.pose.orientation.w = 1
+
+        # Add a collision object to the scenes
+        p2 = PoseStamped()
+        p2.header.frame_id = object_frame
+        p2.pose.position.x = - (object_length + self.base_length) / 2.0
+        p2.pose.position.z = self.collision_height / 2.0
+        p2.pose.orientation.w = 1
+
+        # Add a collision object to the scenes
+        p3 = PoseStamped()
+        p3.header.frame_id = object_frame
+        p3.pose.position.y = (object_length + self.base_length) / 2.0
+        p3.pose.position.z = self.collision_height / 2.0
+        p3.pose.orientation.w = 1
+
+        # Add a collision object to the scenes
+        p4 = PoseStamped()
+        p4.header.frame_id = object_frame
+        p4.pose.position.y = - (object_length + self.base_length) / 2.0
+        p4.pose.position.z = self.collision_height / 2.0
+        p4.pose.orientation.w = 1
+
+        scene.add_box('base0', p0, size=(self.workspace_length, self.workspace_length, 0.1))
+        scene.add_box('base1', p1, size=(object_length, self.base_length, self.collision_height))
+        scene.add_box('base2', p2, size=(object_length, self.base_length, self.collision_height))
+        scene.add_box('base3', p3, size=(self.workspace_length, object_length, self.collision_height))
+        scene.add_box('base4', p4, size=(self.workspace_length, object_length, self.collision_height))
 
         # Initialize state validity check service
         self.state_validity_service = rospy.ServiceProxy('check_state_validity', GetStateValidity)
@@ -111,5 +152,7 @@ class SafeActions(ActionProcessor):
         for i in range(n_checks):
             gsvr.robot_state.joint_state.position = way_points[i, :]
             if not self.state_validity_service.call(gsvr).valid:
+                if i == 0:
+                    rospy.logwarn("Current state in collision!")
                 return way_points[max(i - 1, 0)]
         return goal_position

--- a/eager_process_safe_actions/src/eager_process_safe_actions/safe_actions_processor.py
+++ b/eager_process_safe_actions/src/eager_process_safe_actions/safe_actions_processor.py
@@ -11,7 +11,10 @@ class SafeActionsProcessor(EngineParams):
                  object_frame: str,
                  checks_per_rad: int,
                  duration: float,
-                 vel_limit: float):
+                 vel_limit: float,
+                 collision_height: float,
+                 base_length: float,
+                 workspace_length: float):
         kwargs = locals().copy()
         kwargs.pop('self')
         self.launch_args = kwargs

--- a/eager_robot_ur5e/config/ur5e.yaml
+++ b/eager_robot_ur5e/config/ur5e.yaml
@@ -81,7 +81,7 @@ real:
 
   actuators:
     joints:
-      server_name: follow_joint_trajectory
+      server_name: vel_based_pos_traj_controller/follow_joint_trajectory
       action_server: FollowJointTrajectoryActionServer
       names:
       - shoulder_pan_joint
@@ -90,6 +90,14 @@ real:
       - wrist_1_joint
       - wrist_2_joint
       - wrist_3_joint
+
+  states: # IMPORTANT! Only add states you are able to both read and reset in the physics engine
+    joint_pos:
+      names:
+      -
+    joint_vel:
+      names:
+      -
 
 gazebo:
   default_translation: [0, 0, 0]

--- a/eager_robot_ur5e/launch/real.launch
+++ b/eager_robot_ur5e/launch/real.launch
@@ -1,16 +1,13 @@
 <?xml version="1.0"?>
-<launch>    
+<launch>
   <arg name="ns" default=""  doc="Namespace of the robot." />
+  <arg name="name" default="ur5"  doc="Name of the robot." />
 	<arg name="robot_ip" default="192.168.1.102" doc="IP address of the robot."/>
-	
+
 	<group ns="$(arg ns)">
-		<!-- bringup robot -->
-		<include file="$(find ur_modern_driver)/launch/ur5_bringup.launch">
-		  <arg name="robot_ip" value="$(arg robot_ip)"/>
-		</include>
-
 		<!-- load ros controller -->
-		<include file="$(find ur_modern_driver)/launch/ur5_ros_control.launch"/>
-
+		<include file="$(find ur_modern_driver)/launch/ur5_ros_control.launch">
+			<arg name="robot_ip" value="$(arg robot_ip)"/>
+		</include>
 	</group>
 </launch>

--- a/examples/eager_examples/scripts/example_safe_actions.py
+++ b/examples/eager_examples/scripts/example_safe_actions.py
@@ -54,6 +54,9 @@ class MyEnv(BaseEagerEnv):
                                             checks_per_rad=15,
                                             vel_limit=2.0,
                                             robot_type='ur5e',
+                                            collision_height=0.01,
+                                            base_length=0.4,
+                                            workspace_length=2.4,
                                             )
         self.ur5e.actuators['joints'].add_preprocess(
             launch_path='$(find eager_process_safe_actions)/launch/safe_actions.launch',


### PR DESCRIPTION
This PR fixes some bugs in the real bridge and also updates the safe actions processor. Now, the height can be specified in the safe actions processor, such that the user can define the minimal height for collision free configurations. In this way, one can specify that the robot should not get closer than [collision_height] to the base surface of the robot. Also, two other arguments are added: base_length and workspace_length. The base_length argument defines the length of the sides of a square that is extruded from the collision object, such that the base is not in collision. The workspace length specifies the length of the sides of a square that defines the size of the collision object.