### PR TITLE
Fix Multisense S21

### DIFF
--- a/eager_bridges/eager_bridge_webots/src/eager_bridge_webots/webots_bridge.py
+++ b/eager_bridges/eager_bridge_webots/src/eager_bridge_webots/webots_bridge.py
@@ -266,8 +266,13 @@ class WeBotsBridge(PhysicsBridge):
         else:
             controller = ''
 
-        self._import_robot_service(self._root_node_field, 0, 'DEF {} {} {{ {} {} {} {} {}}}'.format(
-            name, node_type, pos, ori, controller, self_collision, fixed_base))
+        if 'as_child' not in config or config['as_child'] is False:
+            self._import_robot_service(self._root_node_field, 0, 'DEF {} {} {{ {} {} {} {} {}}}'.format(
+                name, node_type, pos, ori, controller, self_collision, fixed_base))
+        else:
+            self._import_robot_service(self._root_node_field, 0, 'DEF {} Robot {{ children [ {} {{ }}]  {} {} {} {} {}}}'.format(
+                name, node_type, pos, ori, controller, self_collision, fixed_base))
+
 
     def _sensor_callback(self, data, name, sensor, pos):
         if data.data != data.data:

--- a/eager_sensors/eager_sensor_multisense_s21/config/dual_cam.yaml
+++ b/eager_sensors/eager_sensor_multisense_s21/config/dual_cam.yaml
@@ -11,6 +11,10 @@ sensors:
     shape: [1024, 544, 4]
 
 webots:
+  node_type_name: MultiSenseS21
+  default_translation: [0, 0, 0]
+  default_orientation: [0.0000001, 0, 0, 0.9999999]
+  as_child: True
   sensors:
     camera_right:
       type: camera


### PR DESCRIPTION
Webots does not allow sensors (or 'devices') to exist without them being tied to a Robot. This PR creates an empty Robot for objects where the as_child field is set to true. Also updates the MS21 config with missing fields